### PR TITLE
Fix missing keys acquisition_era_id and processing_era_id for some DBS2 data

### DIFF
--- a/Server/Python/src/dbs/business/DBSBlockInsert.py
+++ b/Server/Python/src/dbs/business/DBSBlockInsert.py
@@ -503,7 +503,8 @@ acquisition era, but with different cases.")
 
             elif migration and not has_acquisition_era_name:
                 #if no processing era is available, for example for old DBS 2 data, skip insertion
-                pass
+                aq['acquisition_era_id'] = None
+                dataset['acquisition_era_id'] = None
 
             elif migration and not aq['start_date']:
                 aq['start_date'] = 0
@@ -540,7 +541,8 @@ acquisition era, but with different cases.")
                     raise
             elif migration:
                 #if no processing era is available, for example for old DBS 2 data, skip insertion
-                pass
+                pera['processing_era_id'] = None
+                dataset['processing_era_id'] = None
             else:
                 if tran: tran.rollback()
                 if conn: conn.close()


### PR DESCRIPTION
Hi @YuyiGuo,

this patch fixes the problem with missing acquisition_era_id and processing_era_id for datasets from DBS 2, which do not have any aquisition_era and processing_era and are requested to migrate between two DBS 3 instances.

Please, review the code and merge.

Thanks.
Manuel
