### PR TITLE
fix list dataset with acquisition bug. YG

### DIFF
--- a/Server/Python/src/dbs/business/DBSDataset.py
+++ b/Server/Python/src/dbs/business/DBSDataset.py
@@ -136,7 +136,7 @@ class DBSDataset:
             if dataset_access_type: dataset_access_type = dataset_access_type.upper()
             if data_tier_name: data_tier_name = data_tier_name.upper()
             #if  processing_version:  processing_version =  processing_version.upper()
-            if acquisition_era: acquisition_era = acquisition_era.upper()
+            #if acquisition_era: acquisition_era = acquisition_era.upper()
             result = dao.execute(conn, 
                                  dataset, is_dataset_valid,
                                  parent_dataset,


### PR DESCRIPTION
Manuel:

Would you please merge this, rebuit the rpm and test it before submitting the request to HTTP group?
This is the fix to a bug reported by Vincenzo Spinoso vincenzo.spinoso@cern.ch. 
https://cmsweb.cern.ch/dbs/prod/global/DBSReader/datasets?acquisition_era_name=Fall13
returns [], but data was in the DB.
Thanks,
Yuyi
