### PR TITLE
Add Server and Client tests for serverinfo api

### DIFF
--- a/Client/tests/dbsclient_t/deployment/DBSDeployment_t.py
+++ b/Client/tests/dbsclient_t/deployment/DBSDeployment_t.py
@@ -3,6 +3,7 @@ DBS 3 Post-Deployment Tests for Operators of CMSWEB (These tests are read only!)
 """
 import json
 import os
+import re
 import unittest
 from dbs.apis.dbsClient import *
 from dbs.exceptions.dbsClientException import dbsClientException
@@ -781,6 +782,12 @@ DEPLOYMENT_TEST-v4711/RAW",
         self.assertNotEqual(api_doc.find("DBS Server RESTful API"), -1)
         ### test for empty docstrings or errors during doc generation
         self.assertEqual(api_doc.find("No documentation available. Empty docstring!"), -1)
+
+    def test_server_version(self):
+        reg_ex = r'^(3+\.[0-9]+\.[0-9]+[a-z]*$)'
+        version = self.api.serverinfo()
+        self.assertTrue(version.has_key('dbs_version'))
+        self.assertFalse(re.compile(reg_ex).match(version['dbs_version']) is None)
 
 if __name__ == "__main__":
     import sys

--- a/Client/tests/dbsclient_t/unittests/DBSClientReader_t.py
+++ b/Client/tests/dbsclient_t/unittests/DBSClientReader_t.py
@@ -1,9 +1,11 @@
 """
 web unittests
 """
+import imp
 import os
+import re
+import sys
 import unittest
-import sys,imp
 
 from dbs.apis.dbsClient import *
 from dbs.exceptions.dbsClientException import dbsClientException
@@ -572,6 +574,13 @@ class DBSClientReader_t(unittest.TestCase):
     def test106(self):
         """test106: unittestDBSClientReader_t.listRunSummaries: simple run and dataset example"""
         self.api.listRunSummaries(dataset=self.testparams['dataset'], run_num=self.testparams['runs'][0])
+
+    def test107(self):
+        """test107: unittestDBSClientReader_t.serverinfo: get server info"""
+        reg_ex = r'^(3+\.[0-9]+\.[0-9]+[a-z]*$)'
+        version = self.api.serverinfo()
+        self.assertTrue(version.has_key('dbs_version'))
+        self.assertFalse(re.compile(reg_ex).match(version['dbs_version']) is None)
 
 if __name__ == "__main__":
     SUITE = unittest.TestLoader().loadTestsFromTestCase(DBSClientReader_t)

--- a/Client/tests/dbsclient_t/validation/DBSValidation_t.py
+++ b/Client/tests/dbsclient_t/validation/DBSValidation_t.py
@@ -2,14 +2,16 @@
 DBS3 Validation tests
 These tests write and then immediately reads back the data from DBS3 and validate
 """
+from random import choice
 import os
+import re
 import unittest
+import uuid
+
 from dbsclient_t.utils.DBSDataProvider import DBSDataProvider
 from dbsclient_t.utils.timeout import Timeout
 from RestClient.ErrorHandling.RestClientExceptions import HTTPError
 from dbs.apis.dbsClient import *
-import uuid
-from random import choice
 
 uid = uuid.uuid4().time_mid
 print "****uid=%s******" % uid
@@ -445,6 +447,13 @@ class DBSValidation_t(unittest.TestCase):
         block_in_dbs = self.api.listBlocks(block_name=block, detail=True)[0]
         self.assertEqual(block_in_dbs['origin_site_name'], new_site)
         self.assertEqual(block_in_dbs['open_for_writing'], new_open_for_writing)
+
+    def test15(self):
+        """test15: Test to get server information"""
+        reg_ex = r'^(3+\.[0-9]+\.[0-9]+[a-z]*$)'
+        version = self.api.serverinfo()
+        self.assertTrue(version.has_key('dbs_version'))
+        self.assertFalse(re.compile(reg_ex).match(version['dbs_version']) is None)
 
 if __name__ == "__main__":
     SUITE = unittest.TestLoader().loadTestsFromTestCase(DBSValidation_t)

--- a/Server/Python/tests/dbsserver_t/unittests/web_t/DBSReaderModel_t.py
+++ b/Server/Python/tests/dbsserver_t/unittests/web_t/DBSReaderModel_t.py
@@ -1,7 +1,10 @@
 """
 web unittests
 """
-import os, sys, imp
+import imp
+import os
+import re
+import sys
 import unittest
 import time
 from functools import wraps
@@ -1097,6 +1100,13 @@ class DBSReaderModel_t(unittest.TestCase):
     def test027e(self):
         """test027e: web.DBSReaderModel.listRunSummaries: simple run dataset example"""
         api.list('runsummaries', dataset=testparams['dataset'], run_num=testparams['run_num'])
+
+    def test028a(self):
+        """test028a: web.DBSReaderModel.getServerInfo: check that version is returned"""
+        reg_ex = r'^(3+\.[0-9]+\.[0-9]+[a-z]*$)'
+        version = api.list('serverinfo')
+        self.assertTrue(version.has_key('dbs_version'))
+        self.assertFalse(re.compile(reg_ex).match(version['dbs_version']) is None)
 
 if __name__ == "__main__":
     SUITE = unittest.TestLoader().loadTestsFromTestCase(DBSReaderModel_t)

--- a/Server/Python/tests/dbsserver_t/utils/DBSRestApi.py
+++ b/Server/Python/tests/dbsserver_t/utils/DBSRestApi.py
@@ -71,7 +71,8 @@ class DBSRestApi:
             config.DBS.database.connectUrl = dbs3_dp2_i2['connectUrl']['writer']
             config.DBS.database.dbowner = dbs3_dp2_i2['databaseOwner']
             config.DBS.database.engineParameters = { 'pool_size' : 15, 'max_overflow' : 10, 'pool_timeout' : 200 }
-            config.DBS.database.version = getattr(dbsconfig.database.instances, dbinstance).version
+            version = getattr(dbsconfig.database.instances, dbinstance).version
+            config.DBS.database.version = version if version else '3.99.98'
 
             config.DBS.section_('security')
             config.DBS.security.params = {}
@@ -83,7 +84,7 @@ class DBSRestApi:
             config.DBS.database.connectUrl = dbconfig.connectUrl
             config.DBS.database.dbowner = dbconfig.dbowner
             config.DBS.database.engineParameters = dbconfig.engineParameters
-            config.DBS.database.version = dbconfig.version
+            config.DBS.database.version = dbconfig.version if dbconfig.version else '3.99.98'
 
             try:
                 secconfig = getattr(dbsconfig.security.instances, dbinstance)


### PR DESCRIPTION
Hi Yuyi,

this patch adds serverinfo API unittests and fixed https://github.com/dmwm/DBS/issues/292.

Could you review and merge, please?

Thanks,
Manuel
