### PR TITLE
Enable shared curl handles in migration service

### DIFF
--- a/Server/Python/src/dbs/utils/RestClientPool.py
+++ b/Server/Python/src/dbs/utils/RestClientPool.py
@@ -19,8 +19,7 @@ class RestClientPool(object):
         except KeyError:
             self._rest_client_pool[thread_id] = RestApi(auth=self._auth_func(), proxy=self._proxy,
                                                         additional_curl_options={pycurl.NOSIGNAL: 1},
-                                                        use_shared_handle=False)
-            ###use_shared_handle needs to be turned on, when pycurl version is updated in March'14
+                                                        use_shared_handle=True)
             ### see http://linux.die.net/man/3/libcurl-tutorial for thread safety
             return self._rest_client_pool[thread_id]
 


### PR DESCRIPTION
Hi Yuyi,

this patch enables the shared curl handles in the migration service for the March deployment.

Please, merge and review shortly before the March deployment once Diego/Alan has confirmed, that the pycurl version is updated.

Thanks,
Manuel
