### PR TITLE
Bug fix for block origin api, to accept block_name input

### DIFF
--- a/Server/Python/src/dbs/web/DBSReaderModel.py
+++ b/Server/Python/src/dbs/web/DBSReaderModel.py
@@ -111,8 +111,8 @@ class DBSReaderModel(RESTModel):
                         'origin_site_name', 'logical_file_name', 'run_num', 'min_cdate', 'max_cdate', 'min_ldate',
                         'max_ldate', 'cdate', 'ldate', 'detail'], secured=True,
                         security_params={'role': self.security_params, 'authzfunc': authInsert})
-        self._addMethod('GET', 'blockorigin', self.listBlockOrigin, args=['origin_site_name', 'dataset'], secured=True,
-                        security_params={'role': self.security_params, 'authzfunc': authInsert})
+        self._addMethod('GET', 'blockorigin', self.listBlockOrigin, args=['origin_site_name', 'dataset', 'block_name'],
+                        secured=True, security_params={'role': self.security_params, 'authzfunc': authInsert})
         self._addMethod('GET', 'files', self.listFiles, args=['dataset', 'block_name', 'logical_file_name',
                         'release_version', 'pset_hash', 'app_name', 'output_module_label', 'run_num',
                         'origin_site_name', 'lumi_list', 'detail'], secured=True,


### PR DESCRIPTION
Hi Yuyi,

this will fix an upcoming problem I spotted by chance. block_name was not an valid parameter for the listBlockOrigin API.

Could you review and merge, please?

Thanks,
Manuel
