### PR TITLE
fixed the client unittests for search run_num. The unittests failed offt...

### DIFF
--- a/Client/tests/dbsclient_t/unittests/DBSClientReader_t.py
+++ b/Client/tests/dbsclient_t/unittests/DBSClientReader_t.py
@@ -326,12 +326,12 @@ class DBSClientReader_t(unittest.TestCase):
         """test54 unittestDBSClientReader_t.listRuns : basic test"""
         self.api.listRuns(run_num=self.testparams['runs'][1])
 
-    def test055(self):
-        """test55 unittestDBSClientReader_t.listRuns : basic test"""
+    def test055a(self):
+        """test55a unittestDBSClientReader_t.listRuns : basic test"""
         self.api.listRuns(run_num=self.testparams['runs'][2])
 
-    def test055(self):
-        """test55 unittestDBSClientReader_t.listRuns : basic test"""
+    def test055b(self):
+        """test55b unittestDBSClientReader_t.listRuns : basic test"""
         self.api.listRuns(run_num='%s-%s' % (self.testparams['runs'][0], self.testparams['runs'][2]))
 
     def test056(self):

--- a/Client/tests/dbsclient_t/unittests/DBSClientWriter_t.py
+++ b/Client/tests/dbsclient_t/unittests/DBSClientWriter_t.py
@@ -53,7 +53,7 @@ outDict={
 "parent_block" : parent_block,
 "files" : [],
 "parent_files" : [],
-"runs" : [1,2,3],
+"runs" : [97,98,99],
 "acquisition_era" : acquisition_era_name,
 "processing_version" : processing_version,
 }
@@ -194,13 +194,13 @@ class DBSClientWriter_t(unittest.TestCase):
                 'file_size': u'2012211901', 'auto_cross_section': 0.0,
                 'check_sum': u'1504266448',
                 'file_lumi_list': [
-                    {'lumi_section_num': u'27414', 'run_num': u'1'},
-                    {'lumi_section_num': u'26422', 'run_num': u'1'},
-                    {'lumi_section_num': u'29838', 'run_num': u'1'}
+                    {'lumi_section_num': u'27414', 'run_num': u'97'},
+                    {'lumi_section_num': u'26422', 'run_num': u'97'},
+                    {'lumi_section_num': u'29838', 'run_num': u'97'}
                     ],
                 'file_parent_list': [ ],
                 'event_count': u'1619',
-                'logical_file_name': "/store/mc/Fall08/BBJets250to500-madgraph/GEN-SIM-RAW/IDEAL_/%s/%i.root" %(uid, i),
+                'logical_file_name': "/store/mc/Fall08/BBJets250to500-madgraph/GEN-SIM-RAW/IDEAL_/p%s/%i.root" %(uid, i),
                 'block_name': parent_block
                 #'is_file_valid': 1
                 }
@@ -223,11 +223,11 @@ class DBSClientWriter_t(unittest.TestCase):
                 'file_size': u'2012211901', 'auto_cross_section': 0.0,
                 'check_sum': u'1504266448',
                 'file_lumi_list': [
-                    {'lumi_section_num': u'27414', 'run_num': u'1'},
-                    {'lumi_section_num': u'26422', 'run_num': u'2'},
-                    {'lumi_section_num': u'29838', 'run_num': u'3'}
+                    {'lumi_section_num': u'27414', 'run_num': u'97'},
+                    {'lumi_section_num': u'26422', 'run_num': u'98'},
+                    {'lumi_section_num': u'29838', 'run_num': u'99'}
                     ],
-                'file_parent_list': [ {"file_parent_lfn" : "/store/mc/Fall08/BBJets250to500-madgraph/GEN-SIM-RAW/IDEAL_/%s/%i.root" %(uid, i)} ],
+                'file_parent_list': [ {"file_parent_lfn" : "/store/mc/Fall08/BBJets250to500-madgraph/GEN-SIM-RAW/IDEAL_/p%s/%i.root" %(uid, i)} ],
                 'event_count': u'1619',
                 'logical_file_name': "/store/mc/Fall08/BBJets250to500-madgraph/GEN-SIM-RAW/IDEAL_/%s/%i.root" %(uid, i),
                 'block_name': block
@@ -252,11 +252,11 @@ class DBSClientWriter_t(unittest.TestCase):
                 'file_size': u'2012211901', 'auto_cross_section': 0.0,
                 'check_sum': u'1504266448',
                 'file_lumi_list': [
-                    {'lumi_section_num': u'27414', 'run_num': u'1'},
-                    {'lumi_section_num': u'26422', 'run_num': u'2'},
-                    {'lumi_section_num': u'29838', 'run_num': u'3'}
+                    {'lumi_section_num': u'27414', 'run_num': u'97'},
+                    {'lumi_section_num': u'26422', 'run_num': u'98'},
+                    {'lumi_section_num': u'29838', 'run_num': u'99'}
                     ],
-                'file_parent_list': [ {"file_parent_lfn" : "/store/mc/Fall08/BBJets250to500-madgraph/GEN-SIM-RAW/IDEAL_/%s/%i.root" %(uid, i)} ],
+                'file_parent_list': [ {"file_parent_lfn" : "/store/mc/Fall08/BBJets250to500-madgraph/GEN-SIM-RAW/IDEAL_/p%s/%i.root" %(uid, i)} ],
                 'event_count': u'1619',
                 'logical_file_name': "/store/mc/Fall08/BBJets250to500-madgraph/GEN-SIM-RAW/IDEAL_/%s/%i.root" %(uid, i),
                 'block_name': block


### PR DESCRIPTION
...en when test on cmsweb-testbed due to running off the time. This was caused by using run_num=1 that is all the MC data has. We should never search on run_num=1. In additon, the unittests had both parent and child have the same lfns. This was fixed too.
