### PR TITLE
Make sure the DBS client runs inside lightweight CRAB3

### DIFF
--- a/PycurlClient/src/python/RestClient/AuthHandling/X509Auth.py
+++ b/PycurlClient/src/python/RestClient/AuthHandling/X509Auth.py
@@ -87,7 +87,9 @@ class X509Auth(object):
         curl_object.setopt(curl_object.CAPATH, self._ca_path)
         curl_object.setopt(curl_object.SSLCERT, self._ssl_cert)
         curl_object.setopt(curl_object.SSLKEY, self._ssl_key)
-        curl_object.setopt(curl_object.CAINFO, self._ca_info)
+
+        if self._ca_info:
+            curl_object.setopt(curl_object.CAINFO, self._ca_info)
 
         if self.ssl_key_pass:
             curl_object.setopt(curl_object.SSLKEYPASSWD, self.ssl_key_pass)


### PR DESCRIPTION
This is to allow the DBS client work with early versions of pycurl (namely libcurl/7.28.0) so that it can run in the CMSSW environment. Here how you can reproduce the error:


Normal client environment:
```
[erupeika@lxplus063 ~]$ source /cvmfs/cms.cern.ch/crab3/crab.sh
[erupeika@lxplus063 ~]$ curl -V
curl 7.35.0 (x86_64-unknown-linux-gnu) libcurl/7.35.0 OpenSSL/1.0.1r zlib/1.2.8 c-ares/1.10.0
Protocols: dict file ftp ftps gopher http https imap imaps pop3 pop3s rtsp smtp smtps telnet tftp
Features: AsynchDNS IPv6 Largefile NTLM NTLM_WB SSL libz TLS-SRP
[erupeika@lxplus063 ~]$ python testDBSCA.py
[erupeika@lxplus063 ~]$ source /cvmfs/cms.cern.ch/crab3/crab.sh
```

Light client environment:
```
[erupeika@lxplus035 ~]$ source /cvmfs/cms.cern.ch/crab3/crab_light.sh
[erupeika@lxplus035 ~]$ curl -V
curl 7.28.0 (x86_64-unknown-linux-gnu) libcurl/7.28.0 OpenSSL/0.9.8b zlib/1.2.8
Protocols: dict file ftp ftps gopher http https imap imaps pop3 pop3s rtsp smtp smtps telnet tftp
Features: GSS-Negotiate IPv6 Largefile NTLM NTLM_WB SSL libz
[erupeika@lxplus035 ~]$ python testDBSCA.py Traceback (most recent call last):
  File "testDBSCA.py", line 4, in <module>
    curl_object.setopt(curl_object.CAINFO, None)
TypeError: invalid arguments to setopt
```

Test file testDBSCA.py:
```
import pycurl

curl_object = pycurl.Curl()
curl_object.setopt(curl_object.CAINFO, None)
```