### PR TITLE
Update pycurl version

### DIFF
--- a/PycurlClient/requirements.txt
+++ b/PycurlClient/requirements.txt
@@ -1,2 +1,2 @@
 python-cjson==1.2.1
-pycurl==7.19.0.3
+pycurl==7.19.3


### PR DESCRIPTION
We found that the pycurl version for WMAgent and the version for DBS were different.  This PR updates the DBS version to the correct one, keeping it consistent with WMAgent requirements file and the py2-pycurl RPM.