### PR TITLE
Block BriefList: fix max_lday condition

### DIFF
--- a/Server/Python/src/dbs/dao/Oracle/Block/BriefList.py
+++ b/Server/Python/src/dbs/dao/Oracle/Block/BriefList.py
@@ -94,7 +94,7 @@ class BriefList(DBFormatter):
         elif min_ldate != 0 and max_ldate == 0:
             wheresql += "AND B.LAST_MODIFICATION_DATE > :min_ldate "
             binds.update(min_ldate = min_ldate)
-        elif min_cdate ==0 and max_cdate != 0:
+        elif min_ldate ==0 and max_ldate != 0:
             wheresql += "AND B.LAST_MODIFICATION_DATE < :max_ldate "
             binds.update(max_ldate = max_ldate)
         else:


### PR DESCRIPTION
In this condition, it should check for the max last modification date instead of the creation date parameter.

As I was trying to understand the queries performed by the API, I stumbled with this small inconsistency. It is not affecting our current use case, but it may be worth fixing. 