### PR TITLE
Add NATS integration and implement PdmV use case

### DIFF
--- a/Server/Python/src/dbs/web/DBSWriterModel.py
+++ b/Server/Python/src/dbs/web/DBSWriterModel.py
@@ -254,8 +254,9 @@ class DBSWriterModel(DBSReaderModel):
                 try:
                     doc = {'dataset':dataset, 'dataset_type': dataset_access_type}
                     self.nats.publish(doc)
-                except:
-                    pass
+                except Exception as exp:
+                    err = 'insertDataset NATS error, %s, trace:\n%s' % (str(exp), traceback.format_exc())
+                    self.logger.warning(err)
         except cjson.DecodeError as dc:
             dbsExceptionHandler("dbsException-invalid-input2", "Wrong format/data from insert dataset input",  self.logger.exception, str(dc)) 
         except dbsException as de:
@@ -413,8 +414,9 @@ class DBSWriterModel(DBSReaderModel):
                 try:
                     doc = {'dataset':f['dataset'], 'evts': tot_evts, 'size': tot_size}
                     self.nats.publish(doc)
-                except:
-                    pass
+                except Exception as exp:
+                    err = 'insertFile NATS error, %s, trace:\n%s' % (str(exp), traceback.format_exc())
+                    self.logger.warning(err)
         except cjson.DecodeError as dc:
             dbsExceptionHandler("dbsException-invalid-input2", "Wrong format/data from insert File input",  self.logger.exception, str(dc))
         except dbsException as de:
@@ -482,8 +484,9 @@ class DBSWriterModel(DBSReaderModel):
                     try:
                         doc = {'dataset':dataset, 'dataset_type': dataset_access_type}
                         self.nats.publish(doc)
-                    except:
-                        pass
+                    except Exception as exp:
+                        err = 'updateDataset NATS error, %s, trace:\n%s' % (str(exp), traceback.format_exc())
+                        self.logger.warning(err)
             else:
                 dbsExceptionHandler("dbsException-invalid-input", "DBSWriterModel/updateDataset. dataset_access_type is required.")
         except dbsException as de:

--- a/Server/Python/src/dbs/web/DBSWriterModel.py
+++ b/Server/Python/src/dbs/web/DBSWriterModel.py
@@ -18,6 +18,9 @@ from dbs.utils.DBSTransformInputType import transformInputType
 
 import traceback
 
+# CMSMonitoring modules
+from CMSMonitoring.NATS import NATSManager
+
 
 class DBSWriterModel(DBSReaderModel):
     """
@@ -35,6 +38,11 @@ class DBSWriterModel(DBSReaderModel):
 
         if isinstance(urls, type({})):
             config.database.connectUrl = urls['writer']
+
+        # initialize NATS if requested
+        self.nats = None
+        if hasattr(config, 'use_nats') and config.use_nats:
+            self.nats = NATSManager(config.nats_server, topics=config.nats_topics, default_topic='cms.dbs')
 
         DBSReaderModel.__init__(self, config)
 
@@ -240,6 +248,13 @@ class DBSWriterModel(DBSReaderModel):
 
             # need proper validation
             self.dbsDataset.insertDataset(indata)
+            # send message to NATS if it is configured
+            if self.nats:
+                try:
+                    doc = {'dataset':dataset, 'dataset_type': dataset_access_type}
+                    self.nats.publish(doc)
+                except:
+                    pass
         except cjson.DecodeError as dc:
             dbsExceptionHandler("dbsException-invalid-input2", "Wrong format/data from insert dataset input",  self.logger.exception, str(dc)) 
         except dbsException as de:
@@ -375,6 +390,8 @@ class DBSWriterModel(DBSReaderModel):
             if isinstance(indata, dict):
                 indata = [indata]
             indata = validateJSONInputNoCopy("files", indata)
+            tot_size = 0
+            tot_evts = 0
             for f in indata:
                 f.update({
                      #"dataset":f["dataset"],
@@ -387,7 +404,16 @@ class DBSWriterModel(DBSReaderModel):
                      "file_assoc_list":f.get("assoc_list", []),
                      "file_output_config_list":f.get("file_output_config_list", [])})
                 businput.append(f)
+                tot_evts += f.get('event_count', 0)
+                tot_size += f.get('file_size', 0)
             self.dbsFile.insertFile(businput, qInserts)
+            # send message to NATS if it is configured
+            if self.nats and tot_evts and tot_size:
+                try:
+                    doc = {'dataset':f['dataset'], 'evts': tot_evts, 'size': tot_size}
+                    self.nats.publish(doc)
+                except:
+                    pass
         except cjson.DecodeError as dc:
             dbsExceptionHandler("dbsException-invalid-input2", "Wrong format/data from insert File input",  self.logger.exception, str(dc))
         except dbsException as de:
@@ -450,9 +476,15 @@ class DBSWriterModel(DBSReaderModel):
         try:
             if dataset_access_type != "":
                 self.dbsDataset.updateType(dataset, dataset_access_type)
+                # send message to NATS if it is configured
+                if self.nats:
+                    try:
+                        doc = {'dataset':dataset, 'dataset_type': dataset_access_type}
+                        self.nats.publish(doc)
+                    except:
+                        pass
             else:
                 dbsExceptionHandler("dbsException-invalid-input", "DBSWriterModel/updateDataset. dataset_access_type is required.")
-
         except dbsException as de:
             dbsExceptionHandler(de.eCode, de.message, self.logger.exception, de.message)
         except HTTPError as he:

--- a/Server/Python/src/dbs/web/DBSWriterModel.py
+++ b/Server/Python/src/dbs/web/DBSWriterModel.py
@@ -42,7 +42,11 @@ class DBSWriterModel(DBSReaderModel):
         # initialize NATS if requested
         self.nats = None
         if hasattr(config, 'use_nats') and config.use_nats:
-            self.nats = NATSManager(config.nats_server, topics=config.nats_topics, default_topic='cms.dbs')
+            topic = 'cms.dbs'
+            topics = config.nats_topics
+            if not topics:
+                topics = ['%s.topic' % topic]
+            self.nats = NATSManager(config.nats_server, topics=topics, default_topic=topic)
             print("DBS NATS: %s" % self.nats)
 
         DBSReaderModel.__init__(self, config)

--- a/Server/Python/src/dbs/web/DBSWriterModel.py
+++ b/Server/Python/src/dbs/web/DBSWriterModel.py
@@ -43,6 +43,7 @@ class DBSWriterModel(DBSReaderModel):
         self.nats = None
         if hasattr(config, 'use_nats') and config.use_nats:
             self.nats = NATSManager(config.nats_server, topics=config.nats_topics, default_topic='cms.dbs')
+            print("DBS NATS: %s" % self.nats)
 
         DBSReaderModel.__init__(self, config)
 

--- a/Server/Python/src/dbs/web/DBSWriterModel.py
+++ b/Server/Python/src/dbs/web/DBSWriterModel.py
@@ -47,7 +47,8 @@ class DBSWriterModel(DBSReaderModel):
             if not topics:
                 topics = ['%s.topic' % topic]
             self.nats = NATSManager(config.nats_server, topics=topics, default_topic=topic)
-            print("DBS NATS: %s" % self.nats)
+            msg = "DBS NATS: %s" % self.nats
+            self.logger.info(msg)
 
         DBSReaderModel.__init__(self, config)
 


### PR DESCRIPTION
This PR contains the following changes:
- it adds NATSManager from CMSMonitoring and configured it external configuration
- it adds publishing messages upon dataset/file creation to accommodate PdmV (McM) use cases discussed in [CMSMONIT-161](https://its.cern.ch/jira/browse/CMSMONIT-161). In particular, we need to see real-time progress of the following:
  - dataset type change, e.g. from PRODUCTION to VALID
  - dataset growth, e.g. when dataset is updated with new block/file info (since event_count is only provided at file injection level, I updated DBS API at insertFile level)

The interaction with NATS is made optional and safe, i.e. if something happens during NATS publication (e.g. Exception is thrown) the DBS code should not be affected and neither blocked. All NATS publications are done in asynchronous way such that there is no blocking requests.