### PR TITLE
Set proper name for the logger

### DIFF
--- a/Server/Python/src/dbs/web/DBSMigrateModel.py
+++ b/Server/Python/src/dbs/web/DBSMigrateModel.py
@@ -53,6 +53,10 @@ class DBSMigrateModel(RESTModel):
         dbowner = config.database.dbowner
 
         RESTModel.__init__(self, config)
+
+        # set proper logger name
+        self.logger.name = __name__
+
         self.methods = {'GET':{}, 'PUT':{}, 'POST':{}, 'DELETE':{}}
         self.security_params = config.security.params
        

--- a/Server/Python/src/dbs/web/DBSReaderModel.py
+++ b/Server/Python/src/dbs/web/DBSReaderModel.py
@@ -88,6 +88,10 @@ class DBSReaderModel(RESTModel):
         dbowner = config.database.dbowner
 
         RESTModel.__init__(self, config)
+
+        # set proper logger name
+        self.logger.name = __name__
+
         self.dbsUtils2 = dbsUtils()
         self.version = config.database.version
         self.instance = config.instance

--- a/Server/Python/src/dbs/web/DBSWriterModel.py
+++ b/Server/Python/src/dbs/web/DBSWriterModel.py
@@ -41,6 +41,9 @@ class DBSWriterModel(DBSReaderModel):
 
         DBSReaderModel.__init__(self, config)
 
+        # set proper logger name
+        self.logger.name = __name__
+
         # initialize NATS if requested
         self.nats = None
         if hasattr(config, 'use_nats') and config.use_nats:


### PR DESCRIPTION
This PR set proper logger name such that the logger messages can correctly show from which module they come from, e.g. if DBSGlobalWriter issue the logger message it will have this prefix
```
INFO:dbs.web.DBSWriterModel
```
See full discussion over here: https://github.com/dmwm/DBS/issues/629