### PR TITLE
Add additional regexp for dbs2go version tag matching (vXX.YY.ZZ)

### DIFF
--- a/Client/tests/dbsclient_t/unittests/DBSClientReader_t.py
+++ b/Client/tests/dbsclient_t/unittests/DBSClientReader_t.py
@@ -1477,7 +1477,7 @@ class DBSClientReader_t(unittest.TestCase):
 
     def test107(self):
         """test107: unittestDBSClientReader_t.serverinfo: get server info"""
-        reg_ex = r'^(3+\.[0-9]+\.[0-9]+[\.\-a-z0-9]*$)'
+        reg_ex = r'^(3+\.[0-9]+\.[0-9]+[\.\-a-z0-9]*$)|^v[0-9][0-9].[0-9][0-9].[0-9][0-9]'
         version = self.api.serverinfo()
         self.assertTrue('dbs_version' in version)
         self.assertFalse(re.compile(reg_ex).match(version['dbs_version']) is None)


### PR DESCRIPTION
@yuyiguo , in dbs2go I use different set of tagging conventions, like vXX.YY.ZZ. Therefore, to make unit tests match both dbs python tags and dbs2go ones I made this PR.