### PR TITLE
Fix http error parser in the client

### DIFF
--- a/Client/src/python/dbs/apis/dbsClient.py
+++ b/Client/src/python/dbs/apis/dbsClient.py
@@ -220,8 +220,7 @@ class DbsApi(object):
         """
         data = http_error.body
         try:
-            if isinstance(data, str):
-                data = json.loads(data)
+            data = json.loads(data)
         except:
             raise http_error
 


### PR DESCRIPTION
Fixes https://github.com/dmwm/WMCore/issues/10887

The problem is that `data` (http_error.body) is actually a python3 `bytes` object, which means we no longer load that json object and the error message doesn't get propagated to the upstream application.

Making this PR just so we can track it, patch the agents, and make sure this fix is also available in the new DBSClient repo.